### PR TITLE
Minor features

### DIFF
--- a/matex_gen.py
+++ b/matex_gen.py
@@ -3,6 +3,7 @@
 import argparse
 from math import ceil
 from enum import Enum
+from abc import ABC, abstractmethod
 from typing import *
 
 COL_SEP = " & "
@@ -12,8 +13,7 @@ COMPACT_ROWS_NUMBER = 4		# < number of rows when using compact rows -cr
 COMPACT_COLUMNS_NUMBER = 4	# < number of columns when using compact column -cc
 
 
-class Matrix():
-
+class Matrix(ABC):
 	def __init__(self, rows: int, cols: int, lastRow: str, lastCol: str, element: str, generic: bool, diagShift: int):
 		self.rowsNumber = rows
 		self.colsNumber = cols
@@ -23,12 +23,14 @@ class Matrix():
 		self.generic = generic
 		self.diagShift = diagShift
 
+	@abstractmethod
 	def elementAt(self, i: int, j: int) -> str:
 		"""
 		This method is called by self.rows to retrieve a matrix element at the given indexes.
 		A subclass must override this.
 		"""
-		return ""
+		
+		...
 		
 	def rows(self, compactRows: bool, compactCols: bool):
 		"""

--- a/matex_gen.py
+++ b/matex_gen.py
@@ -99,6 +99,14 @@ class CustomMatrix(Matrix):
 	def setCustomElementsList(self, elements):
 		self.elements = elements
 
+class ZeroMatrix(Matrix):
+	def elementAt(self, i: int, j: int) -> str:
+		return "0"
+
+class OnesMatrix(Matrix):
+	def elementAt(self, i: int, j: int) -> str:
+		return "1"
+
 
 class MatrixShape(Enum):
 	"""
@@ -109,6 +117,8 @@ class MatrixShape(Enum):
 	To istantiate the class from the enum value, use the .value property.
 	"""
 	full = FullMatrix
+	zeros = ZeroMatrix
+	ones = OnesMatrix
 	eye = EyeMatrix
 	diag = DiagMatrix
 	triu = TriuMatrix
@@ -172,6 +182,8 @@ if __name__ == "__main__":
 	parser.add_argument("-c", "--columns", help="Matrix columns number. Can be a letter if representing symbolic index.", type=str, default=None, required=True)
 	
 	matrixShapeSubparser = parser.add_subparsers(title="shapes", dest="shape", help="Define matrix shape", required=True)
+	matrixShapeSubparser.add_parser("zeros", help="Generate null matrix of specified dimensions")
+	matrixShapeSubparser.add_parser("ones", help="Generate a matrix full of ones")
 	matrixShapeSubparser.add_parser("full", help="Generate full (complete) matrix")
 	matrixShapeSubparser.add_parser("eye", help="Generate identity matrix")
 	matrixShapeSubparser.add_parser("diag", help="Generate diagonal matrix")


### PR DESCRIPTION
This pull request closes issue #12. A "weak" interface pattern has been adopted: now classes that inherits from Matrix cannot be instantiated until they provide elementAt method. The error rises at runtime.

In triangular upper and lower matrices k-th diagonal can be used, like in Matlab.

Matrices filled with zeros and ones have been implemented